### PR TITLE
X-SaaSus-Trace-Id 自動引継機能の追加

### DIFF
--- a/src/modules/apilog-client.ts
+++ b/src/modules/apilog-client.ts
@@ -13,8 +13,9 @@ export class ApiLogClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -31,8 +32,9 @@ export class ApiLogClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/apilog", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/apilog", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/apilog",

--- a/src/modules/auth-client.ts
+++ b/src/modules/auth-client.ts
@@ -38,8 +38,9 @@ export class AuthClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -56,8 +57,9 @@ export class AuthClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/auth", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/auth", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/auth",

--- a/src/modules/auth-middleware.ts
+++ b/src/modules/auth-middleware.ts
@@ -36,8 +36,12 @@ export async function AuthMiddleware(
   if (req.headers["x-saasus-referer"]) {
     xSaaSusReferer = req.headers["x-saasus-referer"] as string;
   }
+  let xSaaSusTraceId = "";
+  if (req.headers["x-saasus-trace-id"]) {
+    xSaaSusTraceId = req.headers["x-saasus-trace-id"] as string;
+  }
   try {
-    const apiClient = new AuthClient(referer, xSaaSusReferer);
+    const apiClient = new AuthClient(referer, xSaaSusReferer, xSaaSusTraceId);
     const { data } = await apiClient.userInfoApi.getUserInfo(
       isAPI()
         ? req.headers["authorization"]!.split("Bearer ")[1]

--- a/src/modules/awsmarketplace-client.ts
+++ b/src/modules/awsmarketplace-client.ts
@@ -13,8 +13,9 @@ export class AwsMarketplaceClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -31,8 +32,9 @@ export class AwsMarketplaceClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/awsmarketplace", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/awsmarketplace", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/awsmarketplace",

--- a/src/modules/billing-client.ts
+++ b/src/modules/billing-client.ts
@@ -13,8 +13,9 @@ export class BillingClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -31,12 +32,13 @@ export class BillingClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/billing",
     });
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/billing", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/billing", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     this.stripeApi = new StripeApi(config, "", this.instance);
   }

--- a/src/modules/communication-client.ts
+++ b/src/modules/communication-client.ts
@@ -13,8 +13,9 @@ export class CommunicationClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -31,8 +32,9 @@ export class CommunicationClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/communication", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/communication", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/communication",

--- a/src/modules/integration-client.ts
+++ b/src/modules/integration-client.ts
@@ -13,8 +13,9 @@ export class IntegrationClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -31,8 +32,9 @@ export class IntegrationClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/integration", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/integration", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     const config = new Configuration({
       basePath: this.apiBase + "/v1/integration",

--- a/src/modules/interceptor.ts
+++ b/src/modules/interceptor.ts
@@ -6,7 +6,8 @@ import axios, { AxiosError, AxiosInstance, AxiosRequestConfig, InternalAxiosRequ
 export default function getAxiosInstance(
   baseURL: string,
   referer?: string,
-  xSaaSusReferer?: string
+  xSaaSusReferer?: string,
+  xSaaSusTraceId?: string
 ): AxiosInstance {
   const requestConfig: AxiosRequestConfig = {
     baseURL: baseURL,
@@ -35,6 +36,9 @@ export default function getAxiosInstance(
       }
       if (xSaaSusReferer) {
         config.headers!["X-SaaSus-Referer"] = xSaaSusReferer;
+      }
+      if (xSaaSusTraceId) {
+        config.headers!["X-SaaSus-Trace-Id"] = xSaaSusTraceId;
       }
       return config;
     },

--- a/src/modules/pricing-client.ts
+++ b/src/modules/pricing-client.ts
@@ -24,8 +24,9 @@ export class PricingClient {
   private apiBase: string;
   private referer: string;
   private xSaaSusReferer: string;
+  private xSaaSusTraceId: string;
 
-  constructor(referer = "", xSaaSusReferer = "") {
+  constructor(referer = "", xSaaSusReferer = "", xSaaSusTraceId = "") {
     this.secret = process.env.SAASUS_SECRET_KEY || "";
     this.saasId = process.env.SAASUS_SAAS_ID || "";
     this.apiKey = process.env.SAASUS_API_KEY || "";
@@ -46,8 +47,9 @@ export class PricingClient {
 
     this.referer = referer;
     this.xSaaSusReferer = xSaaSusReferer;
+    this.xSaaSusTraceId = xSaaSusTraceId;
 
-    this.instance = getAxiosInstance(this.apiBase + "/v1/pricing", this.referer, this.xSaaSusReferer);
+    this.instance = getAxiosInstance(this.apiBase + "/v1/pricing", this.referer, this.xSaaSusReferer, this.xSaaSusTraceId);
 
     this.meteringApi = new MeteringApi(config, "", this.instance);
     this.pricingMenusApi = new PricingMenusApi(config, "", this.instance);


### PR DESCRIPTION
## 概要
`X-SaaSus-Trace-Id` ヘッダーの自動引継機能を実装しました。

アプリケーションサーバーが `X-SaaSus-Trace-Id` ヘッダーを含むリクエストを受信した場合、その値が同一リクエストライフサイクル内の後続の SaaSus API 呼び出しに自動的に転送されます。

## 変更内容
- `src/modules/interceptor.ts`: `xSaaSusTraceId` を受け取り、axios インターセプターで `X-SaaSus-Trace-Id` ヘッダーを付与
- `src/modules/auth-middleware.ts`: リクエストから `x-saasus-trace-id` を取得し AuthClient に渡す
- 全 `src/modules/*-client.ts`: コンストラクタで `xSaaSusTraceId` を受け取り伝播

## 実装パターン
既存の `X-SaaSus-Referer` の実装と同じパターンに従っています。